### PR TITLE
修复添加任务 表达式生成器回显问题、周标签具体值回显问题、 undefined 以及周期radio选不中问题

### DIFF
--- a/src/agent/Lib/Server.php
+++ b/src/agent/Lib/Server.php
@@ -163,9 +163,9 @@ class Server
         $config = $this->getConfig();
         echo "connect=>host:".$config["host"]." port:".$config["port"]."\n";
         $res = $this->sw->connect($config["host"],$config["port"],30);
-        //https://wiki.swoole.com/wiki/page/30.html 修复Agent和Center网络断开重连连接不上的问题。
+        //https://wiki.swoole.com/wiki/page/30.html 修复Agent和Center网络断开重连连接不上的问题
         if($res === false){
-            $this->sw->close(true);
+            $this->close();
         }
         return $res;
     }

--- a/src/agent/Lib/Server.php
+++ b/src/agent/Lib/Server.php
@@ -162,7 +162,12 @@ class Server
         }
         $config = $this->getConfig();
         echo "connect=>host:".$config["host"]." port:".$config["port"]."\n";
-        return $this->sw->connect($config["host"],$config["port"],30);
+        $res = $this->sw->connect($config["host"],$config["port"],30);
+        //https://wiki.swoole.com/wiki/page/30.html 修复Agent和Center网络断开重连连接不上的问题。
+        if($res === false){
+            $this->sw->close(true);
+        }
+        return $res;
     }
 
     public function getConfig()

--- a/src/public/static/js/crontab.js
+++ b/src/public/static/js/crontab.js
@@ -166,12 +166,13 @@ var Crontab = {
         var day = Crontab.cron_create("v_day");
         var mon = Crontab.cron_create("v_mon");
         var week = Crontab.cron_create("v_week");
-        if (second == undefined) second = '*';
-        if (min == undefined) second = '*';
-        if (hour == undefined) second = '*';
-        if (day == undefined) second = '*';
-        if (mon == undefined) second = '*';
-        if (week == undefined) second = '*';
+
+        if (typeof(second) == "undefined") second = '*';
+        if (typeof(min) == "undefined") min = '*';
+        if (typeof(hour) == "undefined") hour = '*';
+        if (typeof(day) == "undefined") day = '*';
+        if (typeof(mon) == "undefined") mon = '*';
+        if (typeof(week) == "undefined") week = '*';
         var cron = second+" "+min+" "+hour+" "+day+" "+mon+" "+week;
         $("#rule").val(cron);
     },
@@ -182,14 +183,18 @@ var Crontab = {
         var objRadio = $("input[name='" + strid + "']");
         if (strVal == '*'){
             objRadio.eq(0).prop("checked", true);
-        }else if (strVal.split('-').length > 1 && strVal.split('/').length < 1){
+        }
+        //1-23 结构
+        else if (strVal.split('-').length > 1 && strVal.split('/').length <= 1){
             ary = strVal.split('-');
             objRadio.eq(1).prop("checked", true);
             $("#" + strid + "Start_0").val(ary[0]);
             $("#" + strid + "X_0").text( ary[0]);
             $("#" + strid + "End_0").val(ary[1]);
             $("#" + strid + "Y_0").text( ary[1]);
-        }else if (strVal.split('/').length > 1 && strVal.split('-').length < 1)
+        }
+        //*/5 结构
+        else if (strVal.split('/').length > 1 && strVal.split('-').length <= 1)
         {
             ary = strVal.split('/');
             objRadio.eq(2).prop("checked", true);
@@ -218,7 +223,9 @@ var Crontab = {
             $("#" + strid + "Y_1").text( end);
             $("#" + strid + "Loop_1").val( ary[1]);
             $("#" + strid + "Z_1").text( ary[1]);
-        }else if(strVal.split('/').length > 1 && strVal.split('-').length > 1){
+        }
+        //1-23/1 结构
+        else if(strVal.split('/').length > 1 && strVal.split('-').length > 1){
 
             ary = strVal.split('/');
             objRadio.eq(2).prop("checked", true);
@@ -254,10 +261,15 @@ var Crontab = {
             $("#" + strid + "Z_1").text(ary[1]);
 
         }
+        // 1,2,3 规则
         else
         {
+            if(strid == 'v_week'){
+                objRadio.eq(2).attr("checked", "checked");
+            }else{
+                objRadio.eq(3).attr("checked", "checked");
+            }
 
-            objRadio.eq(3).attr("checked", "checked");
             if (strVal != "?")
             {
                 ary = strVal.split(",");
@@ -273,6 +285,9 @@ var Crontab = {
     },
     cron_create:function (strid)
     {
+        if(typeof(strid) == "undefined"){
+            return;
+        }
         var objRadio = $("input[name=" + strid + " ]:checked");
         var type = objRadio.val();
         if (type == 1){


### PR DESCRIPTION
修复如下问题：
1、编辑或者添加任务的时候，如果 点选 周期,从第X秒到第Y秒 保存之后，返回选中了【勾选具体值】问题。
2、点【周】标签之后，没有类似 【从周X开始,到周Y,每Z天执行一次】的选项，所以，如果选中 勾选具体值，保存之后会丢掉选中项。

crontab.js bug。